### PR TITLE
Json config test contains a typo

### DIFF
--- a/ratpack-core/src/test/groovy/ratpack/config/JsonConfigSpec.groovy
+++ b/ratpack-core/src/test/groovy/ratpack/config/JsonConfigSpec.groovy
@@ -127,7 +127,7 @@ class JsonConfigSpec extends BaseConfigSpec {
     configFile.text = ''
 
     when:
-    ServerConfig.of { it.baseDir(baseDir).yaml(configFile) }
+    ServerConfig.of { it.baseDir(baseDir).json(configFile) }
 
     then:
     noExceptionThrown()


### PR DESCRIPTION
ratpack.config.JsonConfigSpec "handles empty json file" test calls yaml() instead of json().